### PR TITLE
Support OpenAI search result format behind env flag

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -282,15 +282,49 @@ def _extract_search_result_title(entity: Any, fallback: str) -> str:
     if isinstance(properties, dict):
         for key in ("name", "title", "displayName"):
             value = properties.get(key)
-            if isinstance(value, str) and value.strip():
+            if value and value.strip():
                 return value
 
     for key in ("displayName", "name", "urn"):
         value = entity.get(key)
-        if isinstance(value, str) and value.strip():
+        if value and value.strip():
             return value
 
     return fallback
+
+
+def _openai_format_search_results(
+    cleaned_response: Any, client: DataHubClient
+) -> Dict[str, List[Dict[str, str]]]:
+    search_results: List[Any] = []
+    if isinstance(cleaned_response, dict):
+        maybe_results = cleaned_response.get("searchResults", [])
+        if isinstance(maybe_results, list):
+            search_results = maybe_results
+
+    openai_results: List[Dict[str, str]] = []
+    for result_item in search_results:
+        if not isinstance(result_item, dict):
+            continue
+
+        entity = result_item.get("entity") or {}
+        if not isinstance(entity, dict):
+            continue
+
+        urn = entity.get("urn")
+        if not urn:
+            continue
+
+        title = _extract_search_result_title(entity, urn)
+
+        url = entity.get("url")
+        if not url:
+            with contextlib.suppress(Exception):
+                url = client._graph.url_for(urn)
+
+        openai_results.append({"id": urn, "title": title, "url": url or urn})
+
+    return {"results": openai_results}
 
 
 @mcp.tool(description="Get an entity by its DataHub URN.")
@@ -378,52 +412,7 @@ def _search_implementation(
     if not is_openai_search_enabled():
         return cleaned_response
 
-    search_results: List[Any] = []
-    if isinstance(cleaned_response, dict):
-        maybe_results = cleaned_response.get("searchResults", [])
-        if isinstance(maybe_results, list):
-            search_results = maybe_results
-
-    openai_results: List[Dict[str, str]] = []
-    for idx, result_item in enumerate(search_results):
-        if not isinstance(result_item, dict):
-            continue
-
-        entity = result_item.get("entity", {})
-        if not isinstance(entity, dict):
-            entity = {}
-
-        urn_value = entity.get("urn")
-        urn: Optional[str]
-        if isinstance(urn_value, str):
-            urn = urn_value
-        elif urn_value is not None:
-            urn = str(urn_value)
-        else:
-            urn = None
-
-        result_id = urn or f"result-{idx + 1}"
-        title = _extract_search_result_title(entity, result_id)
-
-        url = None
-        url_value = entity.get("url")
-        if isinstance(url_value, str) and url_value.strip():
-            url = url_value
-        elif urn:
-            with contextlib.suppress(Exception):
-                maybe_url = client._graph.url_for(urn)
-                if isinstance(maybe_url, str) and maybe_url.strip():
-                    url = maybe_url
-
-        openai_results.append(
-            {
-                "id": result_id,
-                "title": title,
-                "url": url or result_id,
-            }
-        )
-
-    return {"results": openai_results}
+    return _openai_format_search_results(cleaned_response, client)
 
 
 # Define enhanced search tool when semantic search is enabled


### PR DESCRIPTION
## Summary
- add an `OPENAI_SEARCH_ENABLED` toggle and helper to gate OpenAI-specific formatting
- map cleaned search responses to OpenAI's id/title/url schema when the toggle is enabled
- cover the new behavior with unit tests for the OpenAI search response path

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c1f1fa048322a4d6a21730cc4835