### PR TITLE
Add OpenAI-compatible fetch tool

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -135,6 +135,23 @@ async def test_get_domain() -> None:
 
 
 @pytest.mark.anyio
+async def test_fetch_tool(mcp_client: Client) -> None:
+    result = await mcp_client.call_tool("fetch", {"id": _test_urn})
+    assert result.content, "Tool result should have content"
+
+    content = assert_type(TextContent, result.content[0])
+    document = json.loads(content.text)
+
+    assert document["id"] == _test_urn
+    assert document["url"]
+    assert document["metadata"]["source"] == "datahub"
+
+    payload = json.loads(document["text"])
+    assert payload["entity"]["urn"] == _test_urn
+    assert isinstance(payload.get("lineage"), dict)
+
+
+@pytest.mark.anyio
 async def test_get_lineage() -> None:
     res = await get_lineage.fn(_test_urn, column=None, upstream=True, max_hops=1)
     assert res is not None


### PR DESCRIPTION
## Summary
- add a helper to reuse entity detail retrieval logic
- implement a fetch tool that returns OpenAI-compliant document payloads including lineage data
- extend the MCP server test suite to cover the new fetch tool response format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1cf4a6e688322adb14c67d74dac1c